### PR TITLE
Fix timestamp pydantic model conversion

### DIFF
--- a/src/models/processed_latency.py
+++ b/src/models/processed_latency.py
@@ -60,7 +60,7 @@ class ProcessedLatency(BaseModel):
         from_attributes=True
     )
 
-    @field_serializer('window_start_time', 'window_end_time')
+    @field_serializer('window_start_time', 'window_end_time', when_used='json')
     def serialize_datetime_as_timestamp(self, dt: datetime) -> int:
         """Convert datetime to Unix timestamp for JSON serialization"""
         return int(dt.timestamp())


### PR DESCRIPTION
# Error
All timestamps were being serialized into seconds before saved into database. The problem is that they were already serialized by processor so it was doing timestamp /1000 /1000 making the stored star and end time be 1970-01-21 10:23:26.940

# Fix 
Applied serialization  just when exporting model to json

fixes #26 