### PR TITLE
Feature/decision storage

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,7 +14,7 @@ from policy_client import PolicyClient, SyncPolicyClient
 
 KAFKA_HOST = os.getenv("KAFKA_HOST", "localhost")
 KAFKA_PORT = os.getenv("KAFKA_PORT", "9092")
-KAFKA_TOPICS = ["network.data.ingested", "network.data.processed"]
+KAFKA_TOPICS = ["network.data.ingested", "network.data.processed", "network.decisions"]
 
 POLICY_SERVICE_URL = os.getenv("POLICY_SERVICE_URL", "http://policy-service:8000")
 POLICY_COMPONENT_ID = os.getenv("POLICY_COMPONENT_ID", "data-storage")

--- a/sql/03_create_decision_table.sql
+++ b/sql/03_create_decision_table.sql
@@ -1,0 +1,11 @@
+CREATE DATABASE IF NOT EXISTS analytics;
+
+CREATE TABLE IF NOT EXISTS analytics.decisions (
+    cell_id Int32,
+    id UInt64,
+    timestamp DateTime64(3),
+    compression_method String,
+    compressed_data String
+) ENGINE = ReplacingMergeTree()
+PARTITION BY toYYYYMM(timestamp)
+ORDER BY (cell_id, timestamp);

--- a/src/routers/v1/__init__.py
+++ b/src/routers/v1/__init__.py
@@ -4,9 +4,11 @@ from src.routers.v1.cells_router import router as cellR
 from src.routers.v1.processed import router as latencyR
 from src.routers.v1.raw_router import router as rawR
 from src.routers.v1.policy import router as policyR
+from src.routers.v1.decisions import router as decisionsR
 
 v1_router = APIRouter()
 v1_router.include_router(latencyR, prefix="/processed", tags=["v1", "data"])
 v1_router.include_router(rawR, prefix="/raw", tags=["v1", "data"])
 v1_router.include_router(cellR, prefix="/cell", tags=["v1", "cell"])
 v1_router.include_router(policyR, prefix="/policy", tags=["v1", "policy"])
+v1_router.include_router(decisionsR, prefix="/decisions", tags=["v1", "decisions"])

--- a/src/routers/v1/decisions.py
+++ b/src/routers/v1/decisions.py
@@ -1,0 +1,48 @@
+"""
+Endpoints for querying decision data
+"""
+
+from fastapi import APIRouter, HTTPException, Query
+
+from src.services.databases import ClickHouse
+
+router = APIRouter()
+
+
+@router.get("")
+def get_decisions(
+    start_time: int = Query(..., description="Start time (Unix timestamp in seconds)"),
+    end_time: int = Query(..., description="End time (Unix timestamp in seconds)"),
+    cell_id: int | None = Query(None, description="Cell ID filter (optional)"),
+    offset: int = Query(0, ge=0, description="Number of records to skip"),
+    limit: int = Query(100, ge=1, le=1000, description="Maximum number of records to return"),
+):
+    """
+    Query decision data with filters.
+
+    Returns compressed decision data including:
+    - cell_id: Cell identifier
+    - id: Decision record ID
+    - timestamp: When the decision was made
+    - compression_method: Compression algorithm used (e.g., "gzip")
+    - compressed_data: Base64-encoded compressed decision JSON
+
+    To decompress the data:
+    1. Decode base64
+    2. Decompress using the specified compression method
+    3. Parse resulting JSON
+    """
+    try:
+        results = ClickHouse.service.query_decisions(
+            start_time=start_time,
+            end_time=end_time,
+            cell_id=cell_id,
+            offset=offset,
+            limit=limit,
+        )
+        return results
+
+    except Exception as e:
+        raise HTTPException(
+            status_code=500, detail=f"Error querying decisions: {str(e)}"
+        )

--- a/src/services/clickhouse.py
+++ b/src/services/clickhouse.py
@@ -176,3 +176,69 @@ class ClickHouseService:
             metrics = row.pop("metrics", {})
             row.update(metrics)
         return rows
+
+    def query_decisions(
+        self,
+        start_time: int,
+        end_time: int,
+        cell_id: int | None = None,
+        offset: int = 0,
+        limit: int = 100,
+    ) -> list[dict]:
+        """
+        Query decision data from ClickHouse.
+
+        Args:
+            start_time: Filter by timestamp >= start_time (Unix timestamp)
+            end_time: Filter by timestamp <= end_time (Unix timestamp)
+            cell_id: Optional cell_id filter (None = all cells)
+            offset: Number of records to skip
+            limit: Maximum number of records to return
+
+        Returns:
+            List of dicts with decision data (compressed)
+        """
+        params = {
+            "start_time": start_time,
+            "end_time": end_time,
+            "offset": offset,
+            "limit": limit,
+        }
+
+        if cell_id is not None:
+            query = QueryCH.decisions
+            params["cell_id"] = cell_id
+        else:
+            query = QueryCH.decisions_all
+
+        with self._get_client() as client:
+            result = client.query(query, parameters=params)
+
+        column_names = result.column_names
+        return [dict(zip(column_names, row)) for row in result.result_rows]
+
+    def write_decision(
+        self,
+        cell_id: int,
+        timestamp: datetime,
+        compression_method: str,
+        compressed_data: str,
+    ) -> None:
+        """Write a single decision record to ClickHouse"""
+        try:
+            # Auto-generate id based on existing count (simple approach)
+            # ClickHouse will handle this via rowNumberInAllBlocks() for better performance
+            with self._get_client() as client:
+                # Get next ID by counting existing rows for this cell
+                count_query = "SELECT COUNT(*) FROM analytics.decisions WHERE cell_id = {cell_id:Int32}"
+                result = client.query(count_query, parameters={"cell_id": cell_id})
+                next_id = result.result_rows[0][0] + 1
+
+                client.insert(
+                    "analytics.decisions",
+                    [[cell_id, next_id, timestamp, compression_method, compressed_data]],
+                    column_names=["cell_id", "id", "timestamp", "compression_method", "compressed_data"],
+                    settings={"async_insert": 1, "wait_for_async_insert": 0},
+                )
+        except Exception as e:
+            raise Exception(f"Failed to write decision to ClickHouse: {e}")

--- a/src/services/clickhouse_query.py
+++ b/src/services/clickhouse_query.py
@@ -48,3 +48,34 @@ class QueryCH:
     SELECT DISTINCT key
     FROM analytics.metric_keys
     """
+
+    decisions = """
+    SELECT
+        cell_id,
+        id,
+        timestamp,
+        compression_method,
+        compressed_data
+    FROM analytics.decisions
+    WHERE cell_id = {cell_id:Int32}
+      AND toUnixTimestamp(timestamp) >= {start_time:Int64}
+      AND toUnixTimestamp(timestamp) <= {end_time:Int64}
+    ORDER BY timestamp DESC
+    LIMIT {limit:Int32}
+    OFFSET {offset:Int32}
+    """
+
+    decisions_all = """
+    SELECT
+        cell_id,
+        id,
+        timestamp,
+        compression_method,
+        compressed_data
+    FROM analytics.decisions
+    WHERE toUnixTimestamp(timestamp) >= {start_time:Int64}
+      AND toUnixTimestamp(timestamp) <= {end_time:Int64}
+    ORDER BY timestamp DESC
+    LIMIT {limit:Int32}
+    OFFSET {offset:Int32}
+    """

--- a/src/sink.py
+++ b/src/sink.py
@@ -1,8 +1,11 @@
+import base64
+import gzip
 import json
 import logging
 import os
 import threading
 import time
+from datetime import datetime, timezone
 from typing import Optional
 
 from utils.kmw import PyKafBridge
@@ -98,6 +101,47 @@ class KafkaSinkManager:
             success = self.clickhouse_sink.write(filtered_message)
             if not success:
                 logger.error(f"Failed to write to ClickHouse: {filtered_message}")
+        elif topic == "network.decisions":
+            try:
+                # Message format: {"compression": "gzip", "data": "base64..."}
+                compression_method = message.get("compression")
+                compressed_data = message.get("data")
+
+                if not compression_method or not compressed_data:
+                    logger.error(f"Invalid decision message format: {message.keys()}")
+                    return data
+
+                # Decompress to extract cell_id and timestamp
+                decoded = base64.b64decode(compressed_data)
+                if compression_method == "gzip":
+                    decompressed = gzip.decompress(decoded).decode("utf-8")
+                else:
+                    logger.error(f"Unsupported compression method: {compression_method}")
+                    return data
+
+                decision_data = json.loads(decompressed)
+                cell_id = decision_data.get("cell_id")
+                timestamp_str = decision_data.get("timestamp")
+
+                if not cell_id or not timestamp_str:
+                    logger.error(f"Missing cell_id or timestamp in decision: {decision_data.keys()}")
+                    return data
+
+                # Parse ISO timestamp to datetime
+                timestamp = datetime.fromisoformat(timestamp_str.replace("Z", "+00:00"))
+
+                # Write to ClickHouse (stores compressed data)
+                from src.services.databases import ClickHouse
+                ClickHouse.get_service().write_decision(
+                    cell_id=cell_id,
+                    timestamp=timestamp,
+                    compression_method=compression_method,
+                    compressed_data=compressed_data,
+                )
+                logger.info(f"Stored decision for cell {cell_id} at {timestamp}")
+
+            except Exception as e:
+                logger.error(f"Failed to process decision message: {e}")
         else:
             logger.warning(f"Unknown topic: {topic}")
 


### PR DESCRIPTION
## Summary
  Implements storage and querying of decision data from the decision service. Decisions are consumed from Kafka, stored compressed in  ClickHouse, and exposed via REST API endpoints.

## Key decisions

### Compressed storage
- Decisions are light but we want to store the data that was used for that decision and that takes space, the solution here was to save `compression_method` and `compression_data` saving a good amount of space

## Changes

### Clickhouse
- New table: analytics.decisions
    - Columns: cell_id, id, timestamp, compression_method, compressed_data
    - Engine: ReplacingMergeTree() for auto-deduplicates

### Kafka integration
- Subscribed to network.decisions topic

### REST API
- New endpoint: GET /api/v1/decisions

  Query parameters:
  - start_time (required): Unix timestamp in seconds
  - end_time (required): Unix timestamp in seconds
  - cell_id (optional): Filter by specific cell
  - offset (optional): Pagination offset (default: 0)
  - limit (optional): Max records (default: 100, max: 1000)

  Response format:
```json
  [
    {
      "cell_id": 1,
      "id": 1,
      "timestamp": "2026-03-20T21:06:33.482000",
      "compression_method": "gzip",
      "compressed_data": "H4sIAKS1vWkC/72dS28b..."
    }
  ]
```