### PR TITLE
Policy support update for processed data endpoint for ML

### DIFF
--- a/main.py
+++ b/main.py
@@ -68,21 +68,19 @@ async def lifespan(app: FastAPI):
     app.state.policy_client = policy_client
 
     # Initialize database connections (singleton, handles connection internally)
-    Influx.service  # Access triggers lazy initialization
-    ClickHouse.service  # Access triggers lazy initialization
-    load_all()
+    try:
+        Influx.service  # Access triggers lazy initialization + connect
+        ClickHouse.service  # Access triggers lazy initialization + connect
+        load_all()
+        print("Database services initialized")
+    except Exception as e:
+        import traceback
+        print(f"Warning: Failed to initialize database services: {e}")
+        traceback.print_exc()
 
-    # We may not want policy enabled, so we encase it in an if
+    # Register with Policy Service (only when enabled)
     if POLICY_ENABLED:
         try:
-            print("Connecting to InfluxDB...")
-            Influx.service.connect()
-            print("InfluxDB connected")
-
-            print("Connecting to ClickHouse...")
-            ClickHouse.service.connect()
-            print("ClickHouse connected")
-
             # Get fields after services are connected
             print("Getting fields from services...")
             influx_fields = Influx.service.get_fields()
@@ -135,7 +133,8 @@ async def lifespan(app: FastAPI):
 
     yield
 
-    await _async_client.stop_heartbeat()
+    if POLICY_ENABLED:
+        await _async_client.stop_heartbeat()
 
     try:
         await sink_manager.stop()

--- a/src/routers/v1/processed.py
+++ b/src/routers/v1/processed.py
@@ -2,11 +2,18 @@
 Endpoints for query data
 """
 
+import logging
+import os
+
 from fastapi import APIRouter, HTTPException, Query, Header, Request
 
 from src.services.databases import ClickHouse
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter()
+
+POLICY_ENABLED = os.getenv("POLICY_ENABLED", "false").lower() == "true"
 
 
 @router.get("/example")
@@ -63,11 +70,11 @@ def get_processed_data(
     - Network information
     - Statistical measures for each metric
 
-    Policy: If X-Component-ID header is provided, applies policy transformations
-    for the source component reading from data-storage:clickhouse.
+    Policy: If X-Component-ID header is provided and POLICY_ENABLED=true,
+    applies policy transformations for the source component reading from
+    data-storage:clickhouse.
     """
     try:
-        # Build query parameters
         query_params = {
             "start_time": start_time,
             "end_time": end_time,
@@ -80,36 +87,32 @@ def get_processed_data(
 
         results = ClickHouse.service.query_processed(**query_params)
 
-        # Get policy client from app state
-        policy_client = getattr(request.app.state, 'policy_client', None) if hasattr(request, 'app') else None
+        if POLICY_ENABLED and x_component_id:
+            policy_client = getattr(request.app.state, 'policy_client', None) if hasattr(request, 'app') else None
+            if policy_client:
+                source_id = "data-storage:clickhouse"
+                sink_id = x_component_id
+                filtered_results = []
 
-        # Apply policy transformations if source component is provided
-        if x_component_id and policy_client and policy_client._async_client.enable_policy:
-            source_id = "data-storage:clickhouse"
-            sink_id = x_component_id
-            filtered_results = []
+                for row in results:
+                    try:
+                        result = policy_client.process_data(
+                            source_id=source_id,
+                            sink_id=sink_id,
+                            data=row,
+                            action="read"
+                        )
 
-            for row in results:
-                # Apply policy transformation with fail_open safety
-                try:
-                    result = policy_client.process_data(
-                        source_id=source_id,
-                        sink_id=sink_id,
-                        data=row,
-                        action="read"
-                    )
+                        if result.allowed:
+                            filtered_results.append(result.data)
+                    except Exception as e:
+                        if policy_client._async_client.fail_open:
+                            filtered_results.append(row)
+                            logger.warning(f"Policy failed for row, allowing (fail_open): {e}")
+                        else:
+                            logger.warning(f"Policy failed for row, blocking (fail_closed): {e}")
 
-                    if result.allowed:
-                        filtered_results.append(result.data)
-                except Exception as e:
-                    # Apply fail_open behavior
-                    if policy_client._async_client.fail_open:
-                        filtered_results.append(row)
-                        print(f"Policy failed for row, allowing (fail_open): {e}")
-                    else:
-                        print(f"Policy failed for row, blocking (fail_closed): {e}")
-
-            results = filtered_results
+                results = filtered_results
 
         return results
 

--- a/src/routers/v1/raw_router.py
+++ b/src/routers/v1/raw_router.py
@@ -1,8 +1,20 @@
+"""
+Endpoints for raw data queries
+"""
+
+import logging
+import os
+
 from fastapi import APIRouter, HTTPException, Query, Header, Request
 from datetime import datetime
+
 from src.services.databases import Influx
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter()
+
+POLICY_ENABLED = os.getenv("POLICY_ENABLED", "false").lower() == "true"
 
 
 @router.get("")
@@ -20,77 +32,57 @@ def get_raw_data(
     This endpoint returns raw entries directly from the database,
     limited to a maximum of 50 per request.
 
-    Policy: If X-Component-ID header is provided, applies policy transformations
-    for the source component reading from data-storage:influx.
+    Policy: If X-Component-ID header is provided and POLICY_ENABLED=true,
+    applies policy transformations for the source component reading from
+    data-storage:influx.
     """
     try:
-        import sys
-
         query_params = {
             "start_time": start_time,
             "end_time": end_time,
             "cell_index": cell_index,
             "batch_number": batch_number,
         }
-        print(f"API called with: start={start_time}, end={end_time}, cell={cell_index}, source={x_component_id}")
-        sys.stdout.flush()
 
         results, has_next = Influx.service.query_raw_data(**query_params)
-        print(f"Router got {len(results)} results")
-        sys.stdout.flush()
 
-        with_data = [r for r in results if r.get("mean_latency")]
-        print(f"Rows with data: {len(with_data)}")
-        sys.stdout.flush()
+        if POLICY_ENABLED and x_component_id:
+            policy_client = getattr(request.app.state, 'policy_client', None) if hasattr(request, 'app') else None
+            if policy_client:
+                source_id = "data-storage:influx"
+                sink_id = x_component_id
+                filtered_results = []
 
-        # Get policy client from app state
-        policy_client = getattr(request.app.state, 'policy_client', None) if hasattr(request, 'app') else None
+                for row in results:
+                    # Convert datetime objects to strings for policy processing
+                    for k, v in row.items():
+                        if isinstance(v, datetime):
+                            row[k] = v.isoformat()
 
-        # Apply policy transformations if source component is provided
-        if x_component_id and policy_client and policy_client._async_client.enable_policy:
-            # When data-processor requests data from data-storage:
-            # - source_id is the data-processor (the one making the request)
-            # - sink_id is data-storage:influx (the resource being read from)
-            source_id = x_component_id
-            sink_id = "data-storage:influx"
-            print(f"POLICY CHECK: source_id={source_id}, sink_id={sink_id}, action=read")
-            print(f"POLICY CHECK: enable_policy={policy_client._async_client.enable_policy}, fail_open={policy_client._async_client.fail_open}")
-            sys.stdout.flush()
-            filtered_results = []
+                    try:
+                        result = policy_client.process_data(
+                            source_id=source_id,
+                            sink_id=sink_id,
+                            data=row,
+                            action="read"
+                        )
 
-            for row in results:
-                # Convert datetime objects to strings for policy processing
-                for k, v in row.items():
-                    if isinstance(v, datetime):
-                        row[k] = v.isoformat()
+                        if result.allowed:
+                            filtered_results.append(result.data)
+                    except Exception as e:
+                        if policy_client._async_client.fail_open:
+                            filtered_results.append(row)
+                            logger.warning(f"Policy failed for row, allowing (fail_open): {e}")
+                        else:
+                            logger.warning(f"Policy failed for row, blocking (fail_closed): {e}")
 
-                # Apply policy transformation with fail_open safety
-                try:
-                    result = policy_client.process_data(
-                        source_id=source_id,
-                        sink_id=sink_id,
-                        data=row,
-                        action="read"
-                    )
-
-                    print(f"POLICY RESULT: allowed={result.allowed}, reason={result.reason}")
-                    sys.stdout.flush()
-
-                    if result.allowed:
-                        filtered_results.append(result.data)
-                except Exception as e:
-                    # Policy failed - apply fail_open behavior
-                    if policy_client._async_client.fail_open:
-                        # Allow data through on policy failure
-                        filtered_results.append(row)
-                        print(f"Policy failed for row, allowing (fail_open): {e}")
-                    else:
-                        # Block data on policy failure
-                        print(f"Policy failed for row, blocking (fail_closed): {e}")
-
-            results = filtered_results
-            print(f"After policy filter: {len(results)} results")
-            sys.stdout.flush()
+                results = filtered_results
+            else:
+                # No policy client - just convert datetime objects
+                for row in results:
+                    for k, v in row.items():
+                        if isinstance(v, datetime):
+                            row[k] = v.isoformat()
         else:
             # No policy - just convert datetime objects
             for row in results:
@@ -98,13 +90,10 @@ def get_raw_data(
                     if isinstance(v, datetime):
                         row[k] = v.isoformat()
 
-        print(f"Returning {len(results)} results")
-        sys.stdout.flush()
         return {"data": results, "has_next": has_next}
 
     except Exception as e:
-        import traceback
-        traceback.print_exc()
+        logger.error(f"Error querying raw data: {e}")
         raise HTTPException(
             status_code=500, detail=f"Error querying raw data: {str(e)}"
         )

--- a/src/sink.py
+++ b/src/sink.py
@@ -71,33 +71,21 @@ class KafkaSinkManager:
             logger.error(f"Failed to parse message: {e}")
             return data
 
-        if self.policy_client is not None:
-            sink_id = f"{self.policy_client._async_client.component_id}"
-        else:
-            sink_id = "data-storage"
-
+        # Policy is applied upstream by Ingestion/Processor before data reaches Kafka.
+        # Data-Storage writes received data as-is to the appropriate database.
         if topic == "network.data.ingested":
-            sink_id += ":influx"
-            # Support both single records (dict) and batches (list)
+            # Raw data -> InfluxDB
             records = message if isinstance(message, list) else [message]
             for record in records:
-                filtered = self._apply_policy(record, sink_id, topic)
-                if not filtered:
-                    logger.warning(f"Message filtered by policy: sink={sink_id}")
-                else:
-                    with self._buffer_lock:
-                        self._influx_buffer.append(filtered)
+                with self._buffer_lock:
+                    self._influx_buffer.append(record)
             self._maybe_flush()
         elif topic == "network.data.processed":
-            sink_id += ":clickhouse"
+            # Processed data -> ClickHouse
             logger.info(f"Attempting to write to ClickHouse: {list(message.keys())}")
-            filtered_message = self._apply_policy(message, sink_id, topic)
-            if not filtered_message:
-                logger.warning(f"Message filtered by policy: sink={sink_id}")
-            # TODO
-            success = self.clickhouse_sink.write(filtered_message)
+            success = self.clickhouse_sink.write(message)
             if not success:
-                logger.error(f"Failed to write to ClickHouse: {filtered_message}")
+                logger.error(f"Failed to write to ClickHouse: {message}")
         else:
             logger.warning(f"Unknown topic: {topic}")
 
@@ -119,48 +107,6 @@ class KafkaSinkManager:
         # This prevents asyncio.run() from exiting and cancelling the consumer task
         if self.bridge._consumer_task:
             await self.bridge._consumer_task
-
-    # NOTE: This function could in fact not exist, but creating a separate helper function
-    # keeps things tidy and organized
-    def _apply_policy(self, data: dict, sink_id: str, topic: str) -> dict:
-        """
-        Applies policy filtering, sink_id-specific, for differentiation upon configuration
-        (This is so we don't mix raw and processed in Frontend)
-
-        The naming standard should use ":" between the concrete component and the specified sink
-        Example: sink_id = "data-storage:influx"
-        """
-        if (
-            self.policy_client is None
-            or not self.policy_client._async_client.enable_policy
-        ):
-            return data
-
-        try:
-            # Use the sync policy client to process data
-            result = self.policy_client.process_data(
-                source_id="kafka", sink_id=sink_id, data=data, action="write"
-            )
-
-            if result.allowed:
-                return result.data
-            else:
-                logger.warning(
-                    f"Policy blocked: sink={sink_id}, reason={result.reason}"
-                )
-                return {}
-
-        except Exception as e:
-            if self.policy_client._async_client.fail_open:
-                logger.warning(
-                    f"Policy failed for {sink_id}, allowing (fail_open): {e}"
-                )
-                return data
-            else:
-                logger.error(
-                    f"Policy failed for {sink_id}, blocking (fail_closed): {e}"
-                )
-                return {}
 
     async def stop(self):
         self._flush_influx()


### PR DESCRIPTION
This pull request refactors how policy enforcement is handled and improves logging and error handling throughout the data ingestion and API layers. Policy checks are now consistently gated by the `POLICY_ENABLED` flag, and policy enforcement is removed from the data sink, consolidating it in the API layer. Additionally, print statements are replaced with structured logging, and error handling is improved for better observability and maintainability.

Policy checks in both `get_raw_data` (`raw_router.py`) and `get_processed_data` (`processed.py`) are now only applied if the `POLICY_ENABLED` environment variable is set to true, ensuring consistent and configurable policy enforcement.
