### PR TITLE
Add Encryption Support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,7 @@ CLICKHOUSE_TCP_PORT=9000
 CLICKHOUSE_DB=analytics
 CLICKHOUSE_USER=default
 CLICKHOUSE_PASSWORD=changeme
+
+# Encryption (DH key exchange + AES-256-GCM)
+# Set to true to enable the /crypto/handshake endpoint and response encryption
+ENCRYPTION_ENABLED=false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,6 +66,7 @@ services:
       - POLICY_ENABLED=${POLICY_ENABLED}
       - POLICY_FAILOPEN=${POLICY_FAILOPEN}
       - POLICY_ROLENAME=storage
+      - ENCRYPTION_ENABLED=${ENCRYPTION_ENABLED:-false}
     depends_on:
       clickhouse:
         condition: service_started

--- a/main.py
+++ b/main.py
@@ -21,6 +21,8 @@ POLICY_COMPONENT_ID = os.getenv("POLICY_COMPONENT_ID", "data-storage")
 POLICY_ENABLED = os.getenv("POLICY_ENABLED", "false").lower() == "true"
 POLICY_FAILOPEN = os.getenv("POLICY_FAILOPEN", "true").lower() == "true"
 
+ENCRYPTION_ENABLED = os.getenv("ENCRYPTION_ENABLED", "false").lower() == "true"
+
 # Runtime field discovery - updated when data flows through
 _discovered_fields: set[str] = set()
 
@@ -147,3 +149,7 @@ async def lifespan(app: FastAPI):
 app = FastAPI(lifespan=lifespan)
 
 app.include_router(v1_router, prefix="/api/v1", tags=["v1"])
+
+if ENCRYPTION_ENABLED:
+    from encryptor.server.integration import integrate_encryptor
+    integrate_encryptor(app)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "cryptography>=42.0.5",
     "pyyaml>=6.0.0",
     "policy-client-sdk @ git+https://github.com/ATNoG/pei-nwdaf-policy.git#subdirectory=client_sdk",
+    "pei-nwdaf-encryptor @ git+https://github.com/ATNoG/pei-nwdaf-encryptor.git",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
# Summary
Integrates server-side encryption into the Data Storage service using a Diffie-Hellman key exchange followed by AES-256-GCM symmetric encryption, provided by the shared [pei-nwdaf-encryptor](vscode-file://vscode-app/opt/visual-studio-code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) library. When enabled, the service exposes a /crypto/handshake endpoint and transparently encrypts API responses for authenticated clients.

Changes
- main.py — Reads the ENCRYPTION_ENABLED environment variable and, when true, mounts the encryptor integration (integrate_encryptor) into the FastAPI application, activating the handshake endpoint and response encryption middleware

- pyproject.toml — Added pei-nwdaf-encryptor as a direct Git dependency

- docker-compose.yml — Passes ENCRYPTION_ENABLED env var to the service container (defaults to false)

.env.example — Documented the new ENCRYPTION_ENABLED variable with usage notes

Notes
Encryption is opt-in — set ENCRYPTION_ENABLED=true to activate it
Clients that have not performed a handshake receive unencrypted responses as usual, ensuring backwards compatibility
Designed to work together with the ML service's feature/add-encryption-support branch