### PR TITLE
Field discovery adjustments for Policy Service

### DIFF
--- a/src/sink.py
+++ b/src/sink.py
@@ -39,6 +39,9 @@ class KafkaSinkManager:
         self._flush_thread = threading.Thread(target=self._periodic_flush, daemon=True)
         self._flush_thread.start()
 
+        self._influx_fields: set[str] = set()
+        self._clickhouse_fields: set[str] = set()
+
     def _periodic_flush(self):
         while True:
             time.sleep(BATCH_TIMEOUT)
@@ -64,6 +67,24 @@ class KafkaSinkManager:
         ):
             self._flush_influx()
 
+    def _reregister(self) -> None:
+        all_fields = sorted(self._influx_fields | self._clickhouse_fields)
+        try:
+            self.policy_client.register_component(
+                component_type="storage",
+                role=os.getenv("POLICY_ROLENAME", "Storage"),
+                data_columns=all_fields,
+                auto_create_attributes=False,
+                allowed_fields={
+                    "data-storage:influx": sorted(self._influx_fields),
+                    "data-storage:clickhouse": sorted(self._clickhouse_fields),
+                    "*": all_fields,
+                },
+            )
+            logger.info(f"Re-registered with Policy Service ({len(all_fields)} fields discovered)")
+        except Exception as e:
+            logger.warning(f"Failed to re-register with Policy Service: {e}")
+
     def route_message(self, data: dict) -> dict:
         topic: str = data["topic"]
         message_str: str = data["content"]
@@ -79,17 +100,27 @@ class KafkaSinkManager:
         if topic == "network.data.ingested":
             # Raw data -> InfluxDB
             records = message if isinstance(message, list) else [message]
+            prev = len(self._influx_fields)
             for record in records:
+                self._influx_fields.update(record.get("tags", {}).keys())
+                self._influx_fields.update(record.get("metrics", {}).keys())
                 with self._buffer_lock:
                     self._influx_buffer.append(record)
             self._maybe_flush()
+            if self.policy_client and len(self._influx_fields) > prev:
+                self._reregister()
         elif topic == "network.data.processed":
             tags = message.get("tags", {})
             logger.info(f"Writing to ClickHouse: event={tags.get('event')} "
                         f"sst={tags.get('snssai_sst')} dnn={tags.get('dnn')}")
+            prev = len(self._clickhouse_fields)
+            self._clickhouse_fields.update(tags.keys())
+            self._clickhouse_fields.update(message.get("metrics", {}).keys())
             success = self.clickhouse_sink.write(message)
             if not success:
                 logger.error(f"Failed to write to ClickHouse")
+            if self.policy_client and len(self._clickhouse_fields) > prev:
+                self._reregister()
         elif topic == "network.decisions":
             try:
                 # Message format: {"compression": "gzip", "data": "base64..."}


### PR DESCRIPTION
* Added `self._influx_fields` and `self._clickhouse_fields` sets to track all discovered field names for InfluxDB and ClickHouse, respectively, in the `Sink` class constructor.
* Implemented a `_reregister` method to update the Policy Service with the current set of fields, including handling of allowed fields per storage backend and logging registration status.
* Updated `route_message` to track new fields as records are processed for both `network.data.ingested` (InfluxDB) and `network.data.processed` (ClickHouse) topics, and trigger re-registration with the Policy Service only when new fields are discovered.